### PR TITLE
Default port for Kafka and PostgreSQL should be avoided

### DIFF
--- a/choreography/insurance/src/main/resources/application.properties
+++ b/choreography/insurance/src/main/resources/application.properties
@@ -11,8 +11,8 @@ quarkus.log.console.color=false
 # Configure the Kafka source (we read from it)
 smallrye.messaging.source.tickets.type=io.smallrye.reactive.messaging.kafka.Kafka
 smallrye.messaging.source.tickets.topic=tickets
-#smallrye.messaging.source.tickets.bootstrap.servers=kafka:9092
-smallrye.messaging.source.tickets.bootstrap.servers=my-cluster-kafka-bootstrap:9092
+#smallrye.messaging.source.tickets.bootstrap.servers=kafka:9002
+smallrye.messaging.source.tickets.bootstrap.servers=my-cluster-kafka-bootstrap:9002
 smallrye.messaging.source.tickets.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.tickets.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.tickets.group.id=tickets-group-id
@@ -20,7 +20,7 @@ smallrye.messaging.source.tickets.group.id=tickets-group-id
 smallrye.messaging.source.payments.type=io.smallrye.reactive.messaging.kafka.Kafka
 smallrye.messaging.source.payments.topic=payments
 #smallrye.messaging.source.payments.bootstrap.servers=kafka:9092
-smallrye.messaging.source.payments.bootstrap.servers=my-cluster-kafka-bootstrap:9092
+smallrye.messaging.source.payments.bootstrap.servers=my-cluster-kafka-bootstrap:9002
 smallrye.messaging.source.payments.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.payments.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.payments.group.id=payments-insurance-group-id
@@ -28,7 +28,7 @@ smallrye.messaging.source.payments.group.id=payments-insurance-group-id
 #### Database
 
 # configure your datasource
-quarkus.datasource.url: jdbc:postgresql://postgres:5432/insurances
+quarkus.datasource.url: jdbc:postgresql://postgres:5032/insurances
 quarkus.datasource.driver: org.postgresql.Driver
 quarkus.datasource.username: postgres
 quarkus.datasource.password: postgres

--- a/choreography/ticket/src/main/resources/application.properties
+++ b/choreography/ticket/src/main/resources/application.properties
@@ -12,7 +12,7 @@ quarkus.log.console.color=false
 smallrye.messaging.source.payments.type=io.smallrye.reactive.messaging.kafka.Kafka
 smallrye.messaging.source.payments.topic=payments
 #smallrye.messaging.source.payments.bootstrap.servers=kafka:9092
-smallrye.messaging.source.payments.bootstrap.servers=my-cluster-kafka-bootstrap:9092
+smallrye.messaging.source.payments.bootstrap.servers=my-cluster-kafka-bootstrap:9002
 smallrye.messaging.source.payments.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.payments.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 smallrye.messaging.source.payments.group.id=payments-ticket-group-id
@@ -20,7 +20,7 @@ smallrye.messaging.source.payments.group.id=payments-ticket-group-id
 #### Database
 
 # configure your datasource
-quarkus.datasource.url=jdbc:postgresql://postgres:5432/tickets
+quarkus.datasource.url=jdbc:postgresql://postgres:5032/tickets
 quarkus.datasource.driver=org.postgresql.Driver
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres


### PR DESCRIPTION
Many cyber attacks occur due to default port usage.

Reff: https://www.bleepingcomputer.com/news/security/most-cyber-attacks-focus-on-just-three-tcp-ports/#:~:text=According%20to%20the%20report%2C%20the,(Hypertext%20Transfer%20Protocol%20Secure)