### PR TITLE
Add default case for switch statements

### DIFF
--- a/choreography/debezium/src/main/java/com/redhat/demo/saga/elasticsearch/KafkaUtil.java
+++ b/choreography/debezium/src/main/java/com/redhat/demo/saga/elasticsearch/KafkaUtil.java
@@ -121,6 +121,10 @@ public class KafkaUtil {
                     }
                     return obj;
                 }
+                //missing default case
+                default:
+                    // add default case
+                    break;
             }
 
             throw new DataException("Couldn't convert " + value + " to JSON.");


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html